### PR TITLE
Add sd_notify call, transmitting `STOPPING=1` to inform systemd.

### DIFF
--- a/mmcctrld.c
+++ b/mmcctrld.c
@@ -41,6 +41,9 @@ static bool terminate = false;
 
 static void sigterm_handler(int signum)
 {
+#ifdef ENABLE_SYSTEMD
+	sd_notify(0, "STOPPING=1\n");
+#endif
     (void)signum;
     terminate = true;
 }


### PR DESCRIPTION
From [https://www.man7.org/linux/man-pages/man5/systemd.service.5.html](https://www.man7.org/linux/man-pages/man5/systemd.service.5.html):

"Tells the service manager that the service is beginning shutdown. This is useful to allow the service manager to the service's internal state, and present it to the user."
